### PR TITLE
fix(eval): use our own `frexp` to implement `std.exponent` and `std.mantissa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   middle instead of the end.
 - Documentation improvements
 
+### Fixed
+
+- Do not use `f64::log2` to implement `std.exponent` and `std.mantissa`, which
+  can be too inaccurate in some platforms.
+
 ## 0.1.0 (2024-04-06)
 
 - Initial release

--- a/rsjsonnet-lang/src/float.rs
+++ b/rsjsonnet-lang/src/float.rs
@@ -44,3 +44,51 @@ pub(crate) fn try_to_usize_exact(x: f64) -> Option<usize> {
         None
     }
 }
+
+pub(crate) fn frexp(x: f64) -> (f64, i16) {
+    let (norm, edelta) = if x.is_subnormal() {
+        let scale = f64::from_bits((52 + 0x3FF) << 52); // 2^52
+        (x * scale, -52)
+    } else {
+        (x, 0)
+    };
+    let raw = norm.to_bits();
+    let raw_exp = (raw >> 52) & 0x7FF;
+    if raw_exp == 0 {
+        let mant = f64::from_bits(raw & !0x7FFF_FFFF_FFFF_FFFF);
+        let exp = 0;
+        (mant, exp)
+    } else {
+        let mant = f64::from_bits((raw & !(0x7FF << 52)) | (0x3FE << 52));
+        let exp = raw_exp as i16 - 0x3FE + edelta;
+        (mant, exp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::frexp;
+
+    #[test]
+    fn test_frexp() {
+        assert_eq!(frexp(0.0), (0.0, 0));
+        assert_eq!(frexp(0.09375), (0.75, -3));
+        assert_eq!(frexp(-0.09375), (-0.75, -3));
+        assert_eq!(frexp(0.25), (0.5, -1));
+        assert_eq!(frexp(-0.25), (-0.5, -1));
+        assert_eq!(frexp(0.5), (0.5, 0));
+        assert_eq!(frexp(-0.5), (-0.5, 0));
+        assert_eq!(frexp(1.0), (0.5, 1));
+        assert_eq!(frexp(-1.0), (-0.5, 1));
+        assert_eq!(frexp(20.0), (0.625, 5));
+        assert_eq!(frexp(-20.0), (-0.625, 5));
+
+        // Subnormal numbers
+        assert_eq!(frexp(f64::from_bits(0b01)), (0.5, -1073));
+        assert_eq!(frexp(-f64::from_bits(0b01)), (-0.5, -1073));
+        assert_eq!(frexp(f64::from_bits(0b10)), (0.5, -1072));
+        assert_eq!(frexp(-f64::from_bits(0b10)), (-0.5, -1072));
+        assert_eq!(frexp(f64::from_bits(0b11)), (0.75, -1072));
+        assert_eq!(frexp(-f64::from_bits(0b11)), (-0.75, -1072));
+    }
+}

--- a/rsjsonnet-lang/src/program/eval/mod.rs
+++ b/rsjsonnet-lang/src/program/eval/mod.rs
@@ -1372,22 +1372,13 @@ impl<'a> Evaluator<'a> {
                 State::StdExponent => {
                     let arg = self.value_stack.pop().unwrap();
                     let arg = self.expect_std_func_arg_number(arg, "exponent", 0)?;
-                    let exp = if arg == 0.0 {
-                        0.0
-                    } else {
-                        arg.abs().log2().floor() + 1.0
-                    };
-                    self.value_stack.push(ValueData::Number(exp));
+                    let (_, exp) = crate::float::frexp(arg);
+                    self.value_stack.push(ValueData::Number(exp.into()));
                 }
                 State::StdMantissa => {
                     let arg = self.value_stack.pop().unwrap();
                     let arg = self.expect_std_func_arg_number(arg, "mantissa", 0)?;
-                    let mant = if arg == 0.0 {
-                        arg
-                    } else {
-                        let exp = arg.abs().log2().floor() + 1.0;
-                        arg * (-exp).exp2()
-                    };
+                    let (mant, _) = crate::float::frexp(arg);
                     self.value_stack.push(ValueData::Number(mant));
                 }
                 State::StdFloor => {

--- a/ui-tests/pass/stdlib/math.jsonnet
+++ b/ui-tests/pass/stdlib/math.jsonnet
@@ -22,6 +22,8 @@ std.assertEqual(std.max(-2, -1), -1) &&
 std.assertEqual(std.max(1, 1), 1) &&
 
 std.assertEqual(std.exponent(0), 0) &&
+std.assertEqual(std.exponent(0.09375), -3) &&
+std.assertEqual(std.exponent(-0.09375), -3) &&
 std.assertEqual(std.exponent(0.25), -1) &&
 std.assertEqual(std.exponent(-0.25), -1) &&
 std.assertEqual(std.exponent(0.5), 0) &&
@@ -32,8 +34,12 @@ std.assertEqual(std.exponent(1.0), 1) &&
 std.assertEqual(std.exponent(-1.0), 1) &&
 std.assertEqual(std.exponent(1.5), 1) &&
 std.assertEqual(std.exponent(-1.5), 1) &&
+std.assertEqual(std.exponent(20), 5) &&
+std.assertEqual(std.exponent(-20), 5) &&
 
 std.assertEqual(std.mantissa(0), 0) &&
+std.assertEqual(std.mantissa(0.09375), 0.75) &&
+std.assertEqual(std.mantissa(-0.09375), -0.75) &&
 std.assertEqual(std.mantissa(0.25), 0.5) &&
 std.assertEqual(std.mantissa(-0.25), -0.5) &&
 std.assertEqual(std.mantissa(0.5), 0.5) &&
@@ -44,7 +50,8 @@ std.assertEqual(std.mantissa(1.0), 0.5) &&
 std.assertEqual(std.mantissa(-1.0), -0.5) &&
 std.assertEqual(std.mantissa(1.5), 0.75) &&
 std.assertEqual(std.mantissa(-1.5), -0.75) &&
-
+std.assertEqual(std.mantissa(20), 0.625) &&
+std.assertEqual(std.mantissa(-20), -0.625) &&
 
 std.assertEqual(std.floor(-1.75), -2) &&
 std.assertEqual(std.floor(-1.50), -2) &&


### PR DESCRIPTION
Some implementations of `f64::log2` are too inaccurate for this purpose. The new `frexp` implementation operates on the bit representation of the floating point numbers, so it is less subject to platform-dependent floating point weirdness.